### PR TITLE
All sender command channels closed creates infinite loop

### DIFF
--- a/asterisk-ami/src/lib.rs
+++ b/asterisk-ami/src/lib.rs
@@ -108,6 +108,9 @@ impl AmiConnection {
                                 warn!("Error writing to server connection: {:?}", e);
                                 break;
                             }
+                        } else {
+                            trace!("Channel has been closed");
+                            break;
                         }
                     }
                 }
@@ -158,7 +161,7 @@ impl AmiConnection {
 
         trace!("Packet passing loop ended! Publishing 'None' event");
         Self::publish_event(&event_channel_tx, None);
-        
+
         trace!("Closing command channel");
         command_channel_rx.close();
         if let Some(cmd) = current_command {


### PR DESCRIPTION
When an instance of AmiConnection is dropped, all sender channels would be closed but the main server connection loop would stay alive and block a CPU thread.

This happens because, as per channel documentation of tokio, a channel is closed when all senders have been dropped and a call to recv() then returns None, which is not handled in the current loop.

Correct me if I'm wrong, but it seems only a break is required to properly cleanup the connection loop.